### PR TITLE
fix: adyen.environment config validation and documentation - PR for issue #20

### DIFF
--- a/docs/content/en/basic-usage.md
+++ b/docs/content/en/basic-usage.md
@@ -19,8 +19,8 @@ The fastest way to get started with **nuxt-adyen-module** is to define the optio
       apiKey: "<YOUR_API_KEY>",
       origin: "http://localhost:8080",
       channel: "Web | IOS | Android",
-      hmacKey: "dwabhidwbaibdwia",
-      environment: "test | live",
+      hmacKey: "<YOUR_HMAC_KEY_KEY>",
+      environment: "TEST | LIVE",
       clientKey: "<YOUR_CLIENT_KEY>",
     }]
   ],

--- a/docs/content/en/options-reference.md
+++ b/docs/content/en/options-reference.md
@@ -35,6 +35,10 @@ i.e. <http://localhost:8080>
 
 <https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures#enable-hmac-signatures>
 
+## `environment`
+
+`TEST` or `LIVE`
+
 ## `channel`
 
 `Web`, `IOS` or `Android`

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,7 +4,7 @@ import { createMiddleware } from './runtime/middleware'
 import { AdyenClientApi } from './runtime'
 const path = require('path')
 
-export interface ModuleOptions extends AdyenConfigOptions {}
+export interface ModuleOptions extends AdyenConfigOptions { }
 
 const CONFIG_KEY = 'adyen'
 
@@ -14,37 +14,15 @@ const nuxtModule: Module<ModuleOptions> = function (moduleOptions) {
     ...moduleOptions
   }
 
-  if (!options.clientKey) {
-    throw new Error('[nuxt-adyen-module] property clientKey is required')
-  }
-  if (!options.environment) {
-    throw new Error('[nuxt-adyen-module] property environment is required')
-  }
-  if (options.environment && !options.environment.match(/TEST|LIVE/g)) {
-    throw new Error(
-      '[nuxt-adyen-module] property environment supported values are "TEST | LIVE"'
-    )
-  }
-  if (!options.merchantAccount) {
-    throw new Error('[nuxt-adyen-module] property merchantAccount is required')
-  }
-  if (!options.returnUrl) {
-    throw new Error('[nuxt-adyen-module] property returnUrl is required')
-  }
-  if (!options.origin) {
-    throw new Error('[nuxt-adyen-module] property origin is required')
-  }
-  if (!options.checkoutEndpoint) {
-    throw new Error(
-      '[nuxt-adyen-module] property checkoutEndpoint is required'
-    )
-  }
-  if (!options.apiKey) {
-    throw new Error('[nuxt-adyen-module] property apiKey is required')
-  }
-  if (!options.channel) {
-    throw new Error('[nuxt-adyen-module] property channel is required')
-  }
+  if (!options.clientKey) { throw new Error('[nuxt-adyen-module] property clientKey is required') }
+  if (!options.environment) { throw new Error('[nuxt-adyen-module] property environment is required') }
+  if (options.environment && !options.environment.match(/TEST|LIVE/g)) { throw new Error('[nuxt-adyen-module] property environment supported values are "TEST | LIVE"') }
+  if (!options.merchantAccount) { throw new Error('[nuxt-adyen-module] property merchantAccount is required') }
+  if (!options.returnUrl) { throw new Error('[nuxt-adyen-module] property returnUrl is required') }
+  if (!options.origin) { throw new Error('[nuxt-adyen-module] property origin is required') }
+  if (!options.checkoutEndpoint) { throw new Error('[nuxt-adyen-module] property checkoutEndpoint is required') }
+  if (!options.apiKey) { throw new Error('[nuxt-adyen-module] property apiKey is required') }
+  if (!options.channel) { throw new Error('[nuxt-adyen-module] property channel is required') }
 
   const runtimeDir = path.resolve(__dirname, 'runtime')
   this.nuxt.options.alias['~adyen'] = runtimeDir
@@ -64,13 +42,13 @@ const nuxtModule: Module<ModuleOptions> = function (moduleOptions) {
 
 declare module '@nuxt/types' {
   interface NuxtConfig {
-    [CONFIG_KEY]: ModuleOptions;
+    [CONFIG_KEY]: ModuleOptions
   } // Nuxt 2.14+
   interface Configuration {
-    [CONFIG_KEY]: ModuleOptions;
+    [CONFIG_KEY]: ModuleOptions
   } // Nuxt 2.9 - 2.13
   interface Context {
-    $adyen: AdyenClientApi;
+    $adyen: AdyenClientApi
   }
 }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,14 +14,37 @@ const nuxtModule: Module<ModuleOptions> = function (moduleOptions) {
     ...moduleOptions
   }
 
-  if (!options.clientKey) { throw new Error('[nuxt-adyen-module] property clientKey is required') }
-  if (!options.environment) { throw new Error('[nuxt-adyen-module] property environment is required') }
-  if (!options.merchantAccount) { throw new Error('[nuxt-adyen-module] property merchantAccount is required') }
-  if (!options.returnUrl) { throw new Error('[nuxt-adyen-module] property returnUrl is required') }
-  if (!options.origin) { throw new Error('[nuxt-adyen-module] property origin is required') }
-  if (!options.checkoutEndpoint) { throw new Error('[nuxt-adyen-module] property checkoutEndpoint is required') }
-  if (!options.apiKey) { throw new Error('[nuxt-adyen-module] property apiKey is required') }
-  if (!options.channel) { throw new Error('[nuxt-adyen-module] property channel is required') }
+  if (!options.clientKey) {
+    throw new Error('[nuxt-adyen-module] property clientKey is required')
+  }
+  if (!options.environment) {
+    throw new Error('[nuxt-adyen-module] property environment is required')
+  }
+  if (options.environment && !options.environment.match(/TEST|LIVE/g)) {
+    throw new Error(
+      '[nuxt-adyen-module] property environment supported values are "TEST | LIVE"'
+    )
+  }
+  if (!options.merchantAccount) {
+    throw new Error('[nuxt-adyen-module] property merchantAccount is required')
+  }
+  if (!options.returnUrl) {
+    throw new Error('[nuxt-adyen-module] property returnUrl is required')
+  }
+  if (!options.origin) {
+    throw new Error('[nuxt-adyen-module] property origin is required')
+  }
+  if (!options.checkoutEndpoint) {
+    throw new Error(
+      '[nuxt-adyen-module] property checkoutEndpoint is required'
+    )
+  }
+  if (!options.apiKey) {
+    throw new Error('[nuxt-adyen-module] property apiKey is required')
+  }
+  if (!options.channel) {
+    throw new Error('[nuxt-adyen-module] property channel is required')
+  }
 
   const runtimeDir = path.resolve(__dirname, 'runtime')
   this.nuxt.options.alias['~adyen'] = runtimeDir
@@ -35,19 +58,19 @@ const nuxtModule: Module<ModuleOptions> = function (moduleOptions) {
     fileName: 'adyen.js',
     options: { registerCheckoutComponent: options.registerCheckoutComponent }
   })
-}
+};
 
-;(nuxtModule as any).meta = require('../package.json')
+(nuxtModule as any).meta = require('../package.json')
 
 declare module '@nuxt/types' {
   interface NuxtConfig {
-    [CONFIG_KEY]: ModuleOptions
+    [CONFIG_KEY]: ModuleOptions;
   } // Nuxt 2.14+
   interface Configuration {
-    [CONFIG_KEY]: ModuleOptions
+    [CONFIG_KEY]: ModuleOptions;
   } // Nuxt 2.9 - 2.13
   interface Context {
-    $adyen: AdyenClientApi
+    $adyen: AdyenClientApi;
   }
 }
 

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -22,16 +22,7 @@ describe('module', () => {
   })
 
   test('should have config with Adyen options', () => {
-    const {
-      merchantAccount,
-      environment,
-      clientKey,
-      returnUrl,
-      checkoutEndpoint,
-      apiKey,
-      origin,
-      channel
-    } = getNuxt().options.adyen
+    const { merchantAccount, environment, clientKey, returnUrl, checkoutEndpoint, apiKey, origin, channel } = getNuxt().options.adyen
 
     expect(merchantAccount).toBeDefined()
     expect(returnUrl).toBeDefined()

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -22,7 +22,16 @@ describe('module', () => {
   })
 
   test('should have config with Adyen options', () => {
-    const { merchantAccount, environment, clientKey, returnUrl, checkoutEndpoint, apiKey, origin, channel } = getNuxt().options.adyen
+    const {
+      merchantAccount,
+      environment,
+      clientKey,
+      returnUrl,
+      checkoutEndpoint,
+      apiKey,
+      origin,
+      channel
+    } = getNuxt().options.adyen
 
     expect(merchantAccount).toBeDefined()
     expect(returnUrl).toBeDefined()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix for Issue https://github.com/Baroshem/nuxt-adyen-module/issues/20

## Description
<!--- Describe your changes in detail -->
Limit the ayden.environment config option to only TEST and LIVE values

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Baroshem/nuxt-adyen-module/issues/20

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The Module is broken and unusable when wrong config is provided.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, since there is no friendly unit testing setup provided.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
