### PR TITLE
fix: convert handleShopperRedirect endpoint from POST to GET

### DIFF
--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -4,41 +4,74 @@ import { PaymentMethodsResponse } from '@adyen/api-library/lib/src/typings/check
 import { PaymentResponse } from '@adyen/api-library/lib/src/typings/checkout/paymentResponse'
 import { AdyenCheckoutClient, Amount, LocalStore } from './api'
 
-export const sendRequestToServer = async <RETURN_TYPE>(method: string, url: string, data?: any) => {
+export const sendRequestToServer = async <RETURN_TYPE>(
+  method: string,
+  url: string,
+  data?: any
+) => {
   const result: RETURN_TYPE = await fetch(url, {
     method,
     headers: {
       'Content-Type': 'application/json'
     },
     body: data ? JSON.stringify(data) : null
-  }).then(res => res.json())
+  })
+    .then(res => res.json())
     .catch(error => ({ error }))
 
   return result
 }
 
 export class AdyenClientApi implements AdyenCheckoutClient {
-  async createPaymentSession (amount: Amount): Promise<CreateCheckoutSessionResponse> {
-    return await sendRequestToServer<CreateCheckoutSessionResponse>('POST', '/api/createPaymentSession', amount)
+  async createPaymentSession (
+    amount: Amount
+  ): Promise<CreateCheckoutSessionResponse> {
+    return await sendRequestToServer<CreateCheckoutSessionResponse>(
+      'POST',
+      '/api/createPaymentSession',
+      amount
+    )
   }
 
   async getPaymentMethods (): Promise<PaymentMethodsResponse> {
-    return await sendRequestToServer<PaymentMethodsResponse>('GET', '/api/getPaymentMethods')
+    return await sendRequestToServer<PaymentMethodsResponse>(
+      'GET',
+      '/api/getPaymentMethods'
+    )
   }
 
-  async submitAdditionalDetails (paymentDetailsRequest: DetailsRequest): Promise<PaymentResponse> {
-    return await sendRequestToServer<PaymentResponse>('POST', '/api/submitAdditionalDetails', paymentDetailsRequest)
+  async submitAdditionalDetails (
+    paymentDetailsRequest: DetailsRequest
+  ): Promise<PaymentResponse> {
+    return await sendRequestToServer<PaymentResponse>(
+      'POST',
+      '/api/submitAdditionalDetails',
+      paymentDetailsRequest
+    )
   }
 
-  async handleShopperRedirect (paymentDetailsRequest: DetailsRequest): Promise<void> {
-    await sendRequestToServer<void>('POST', '/api/handleShopperRedirect', paymentDetailsRequest)
+  async handleShopperRedirect (
+    paymentDetailsRequest: DetailsRequest
+  ): Promise<void> {
+    await sendRequestToServer<void>(
+      'GET',
+      '/api/handleShopperRedirect',
+      paymentDetailsRequest
+    )
   }
 
   async initiatePayment (data: any): Promise<PaymentResponse> {
-    return await sendRequestToServer<PaymentResponse>('POST', '/api/initiatePayment', data)
+    return await sendRequestToServer<PaymentResponse>(
+      'POST',
+      '/api/initiatePayment',
+      data
+    )
   }
 
   async getPaymentDataStore (): Promise<LocalStore> {
-    return await sendRequestToServer<LocalStore>('GET', '/api/getPaymentDataStore')
+    return await sendRequestToServer<LocalStore>(
+      'GET',
+      '/api/getPaymentDataStore'
+    )
   }
 }

--- a/src/runtime/middleware.ts
+++ b/src/runtime/middleware.ts
@@ -22,11 +22,15 @@ export const createMiddleware = (configuration: AdyenConfigOptions) => {
   app.get("/api/getPaymentMethods", async (req: any, res: any) => {
     const result = await adyenServerApi.getPaymentMethods()
 
-    res.send({ result, clientKey: configuration.clientKey, environment: configuration.environment })
+    res.send({
+      result,
+      clientKey: configuration.clientKey,
+      environment: configuration.environment
+    })
   })
 
   // eslint-disable-next-line
-  app.post('/api/createPaymentSession', async (req: any, res: any) => {
+  app.post("/api/createPaymentSession", async (req: any, res: any) => {
     const result = await adyenServerApi.createPaymentSession(req.body)
 
     res.send(result)
@@ -53,8 +57,8 @@ export const createMiddleware = (configuration: AdyenConfigOptions) => {
   })
 
   // eslint-disable-next-line
-  app.post("/api/handleShopperRedirect", async (req: any, res: any) => {
-    const redirect = req.body
+  app.get("/api/handleShopperRedirect", async (req: any, res: any) => {
+    const redirect = req.query
     const details: PaymentCompletionDetails = {}
     if (redirect.redirectResult) {
       details.redirectResult = redirect.redirectResult
@@ -63,14 +67,18 @@ export const createMiddleware = (configuration: AdyenConfigOptions) => {
     }
     const orderRef = req?.query?.orderRef
 
-    const response = await adyenServerApi.getPaymentsDetails({ details }, orderRef)
+    const response = await adyenServerApi.getPaymentsDetails(
+      { details },
+      orderRef
+    )
 
     redirectByCode(res, response.resultCode)
   })
 
   // eslint-disable-next-line
   app.post("/api/webhook/notification", (req: any, res: any) => {
-    const notificationRequestItems: NotificationRequestItem[] = req.body.notificationItems
+    const notificationRequestItems: NotificationRequestItem[] =
+      req.body.notificationItems
 
     adyenServerApi.handleNotificationWebhook(notificationRequestItems)
 

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -1,11 +1,29 @@
-import { CheckoutAPI, Client, hmacValidator as HmacValidator, Modification } from '@adyen/api-library'
+import {
+  CheckoutAPI,
+  Client,
+  hmacValidator as HmacValidator,
+  Modification
+} from '@adyen/api-library'
 import { DetailsRequest } from '@adyen/api-library/lib/src/typings/checkout/detailsRequest'
 import { PaymentResponse } from '@adyen/api-library/lib/src/typings/checkout/paymentResponse'
 import { CreateCheckoutSessionResponse } from '@adyen/api-library/lib/src/typings/checkout/createCheckoutSessionResponse'
 import { PaymentMethodsResponse } from '@adyen/api-library/lib/src/typings/checkout/paymentMethodsResponse'
 import { NotificationRequestItem } from '@adyen/api-library/lib/src/typings/notification/notificationRequestItem'
-import { AdyenCheckoutServer, AdyenConfigOptions, Amount, InitiatePaymentBody, LocalStore } from './api'
-import { createBillingAddress, createCountryCode, createPaymentMethod, createUniqueReference, findCurrency, findPayment } from './utils'
+import {
+  AdyenCheckoutServer,
+  AdyenConfigOptions,
+  Amount,
+  InitiatePaymentBody,
+  LocalStore
+} from './api'
+import {
+  createBillingAddress,
+  createCountryCode,
+  createPaymentMethod,
+  createUniqueReference,
+  findCurrency,
+  findPayment
+} from './utils'
 
 export class AdyenServerApi implements AdyenCheckoutServer {
   private readonly checkout: CheckoutAPI
@@ -35,7 +53,10 @@ export class AdyenServerApi implements AdyenCheckoutServer {
     })
   }
 
-  async createPaymentSession ({ currency, value }: Amount): Promise<CreateCheckoutSessionResponse> {
+  async createPaymentSession ({
+    currency,
+    value
+  }: Amount): Promise<CreateCheckoutSessionResponse> {
     try {
       const response = await this.checkout.sessions({
         merchantAccount: this._config.merchantAccount,
@@ -68,13 +89,20 @@ export class AdyenServerApi implements AdyenCheckoutServer {
     }
   }
 
-  async getPaymentsDetails (paymentDetailsRequest: DetailsRequest, orderRef: string) {
+  async getPaymentsDetails (
+    paymentDetailsRequest: DetailsRequest,
+    orderRef: string
+  ) {
     try {
-      const response = await this.checkout.paymentsDetails(paymentDetailsRequest)
+      const response = await this.checkout.paymentsDetails(
+        paymentDetailsRequest
+      )
 
       if (!response.action) {
-        this.paymentStore[orderRef].paymentRef = response.pspReference
-        this.paymentStore[orderRef].status = response.resultCode
+        this.paymentStore[orderRef] = {
+          paymentRef: response.pspReference,
+          status: response.resultCode
+        }
       }
 
       return response
@@ -87,7 +115,8 @@ export class AdyenServerApi implements AdyenCheckoutServer {
   // eslint-disable-next-line
   async initiatePayment(req: any): Promise<PaymentResponse> {
     try {
-      const shopperIP = req.headers['x-forwarded-for'] || req.connection.remoteAddress
+      const shopperIP =
+        req.headers['x-forwarded-for'] || req.connection.remoteAddress
       const initiatePaymentBody: InitiatePaymentBody = req.body
       const currency = findCurrency(initiatePaymentBody)
       const orderRef = createUniqueReference()
@@ -134,8 +163,10 @@ export class AdyenServerApi implements AdyenCheckoutServer {
           this.originStore[orderRef] = originalHost.origin
         }
       } else {
-        this.paymentStore[orderRef].paymentRef = response.pspReference
-        this.paymentStore[orderRef].status = response.resultCode
+        this.paymentStore[orderRef] = {
+          paymentRef: response.pspReference,
+          status: response.resultCode
+        }
       }
 
       return response
@@ -145,17 +176,28 @@ export class AdyenServerApi implements AdyenCheckoutServer {
     }
   }
 
-  handleNotificationWebhook (notificationRequestItems: NotificationRequestItem[]): void {
+  handleNotificationWebhook (
+    notificationRequestItems: NotificationRequestItem[]
+  ): void {
     notificationRequestItems.forEach((notificationItem) => {
       const { NotificationRequestItem }: any = notificationItem // Wrong typing in Adyen package
       if (NotificationRequestItem.eventCode === 'CANCEL_OR_REFUND') {
-        if (this.validator.validateHMAC(NotificationRequestItem, this._config.hmacKey)) {
-          const payment = findPayment(NotificationRequestItem.pspReference, this.paymentStore)
+        if (
+          this.validator.validateHMAC(
+            NotificationRequestItem,
+            this._config.hmacKey
+          )
+        ) {
+          const payment = findPayment(
+            NotificationRequestItem.pspReference,
+            this.paymentStore
+          )
 
           if (NotificationRequestItem.success === 'true') {
             if (
               'modification.action' in NotificationRequestItem.additionalData &&
-              NotificationRequestItem.additionalData['modification.action'] === 'refund'
+              NotificationRequestItem.additionalData['modification.action'] ===
+                'refund'
             ) {
               payment.status = 'Refunded'
             } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix for issue https://github.com/Baroshem/nuxt-adyen-module/issues/21

## Description
<!--- Describe your changes in detail -->
Converted `/api/handleShopperRedirect` from POST to GET, because on payment success redirect this endpoint was not invoked.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Baroshem/nuxt-adyen-module/issues/21

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ability to complete the whole flow after a payment is completed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually since there is no friendly unit test setup provided.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
